### PR TITLE
Add support for Caveat header to finding_details

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inspecjs",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "© 2018 The MITRE Corporation.",
   "files": [
     "dist"

--- a/src/compat_impl/compat_inspec_1_0.ts
+++ b/src/compat_impl/compat_inspec_1_0.ts
@@ -57,7 +57,11 @@ abstract class HDFControl_1_0 implements HDFControl {
             case "Not Reviewed":
                 return `Automated test skipped due to known accepted condition in the control:\n\n${this.message}\n`;
             case "Not Applicable":
-                return `Justification:\n\n${this.message}\n`;
+                if("caveat" in this.descriptions) {
+                    return `Caveat:\n\n${this.message}\n`;
+                } else {
+                    return `Justification:\n\n${this.message}\n`;
+                }
             case "Profile Error":
                 if (!this.status_list || this.status_list.length === 0) {
                     return "No describe blocks were run in this control";

--- a/src/compat_impl/compat_inspec_1_0.ts
+++ b/src/compat_impl/compat_inspec_1_0.ts
@@ -57,7 +57,9 @@ abstract class HDFControl_1_0 implements HDFControl {
             case "Not Reviewed":
                 return `Automated test skipped due to known accepted condition in the control:\n\n${this.message}\n`;
             case "Not Applicable":
-                if("caveat" in this.descriptions) {
+                // Overlays may use "caveat" keyed text to indicate why certain
+                // controls are not applicable
+                if("caveat" in this.descriptions || "caveat" in this.wraps.tags) {
                     return `Caveat:\n\n${this.message}\n`;
                 } else {
                     return `Justification:\n\n${this.message}\n`;

--- a/src/compat_impl/compat_inspec_1_0.ts
+++ b/src/compat_impl/compat_inspec_1_0.ts
@@ -59,7 +59,9 @@ abstract class HDFControl_1_0 implements HDFControl {
             case "Not Applicable":
                 // Overlays may use "caveat" keyed text to indicate why certain
                 // controls are not applicable
-                if("caveat" in this.descriptions || "caveat" in this.wraps.tags) {
+                if("caveat" in this.descriptions || "caveat" in this.wraps.tags
+                    || "Caveat" in this.descriptions || "Caveat" in this.wraps.tags) 
+                {
                     return `Caveat:\n\n${this.message}\n`;
                 } else {
                     return `Justification:\n\n${this.message}\n`;


### PR DESCRIPTION
Under the Not Applicable case, finding_details() are preceded with
"Justification" by default. With this commit, if a "caveat" description
exists then the phrase "Caveat" will be used instead of "Justification".

This is primarily to support a common pattern used in the CMS overlays

Signed-off-by: Luke Malinowski <lmalinowski@mitre.org>